### PR TITLE
Implement item search feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ py main.py
 - Find Trigger
 - Find Webhooks
 - Find Variables
+- Find Items (shows item images)


### PR DESCRIPTION
## Summary
- add a new `ItemScanner` worker
- introduce "Items" tab to view item images in a grid
- hook item search into run-all-scans
- update README with new feature

## Testing
- `python3 -m py_compile GUI/femdumpergui.py`

------
https://chatgpt.com/codex/tasks/task_e_686e3083392c8333aad6ec903171d969