### PR TITLE
Fix geometry warning by limiting table height

### DIFF
--- a/GUI/femdumpergui.py
+++ b/GUI/femdumpergui.py
@@ -671,6 +671,9 @@ class FemDumperApp(QMainWindow):
             "Risk Level",
             "Actions",
         ])
+        # Prevent very large minimum sizes when many rows are displayed
+        self.trigger_table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.trigger_table.setMaximumHeight(600)
         header = self.trigger_table.horizontalHeader()
         header.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
         header.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)


### PR DESCRIPTION
## Summary
- set a maximum height for the trigger table to avoid large minimum window sizes

## Testing
- `python -m py_compile GUI/femdumpergui.py`
- `python GUI/femdumpergui.py` *(fails: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6880919b3680833397f1153493664619